### PR TITLE
allow EOF to be a graceful exit from repl

### DIFF
--- a/sigmaF/repl.py
+++ b/sigmaF/repl.py
@@ -183,9 +183,16 @@ def start_repl(source: str = '', _path: Optional[str] = None) -> None:
 
     _pattern_path = re.compile(r'load\(([\w\.-_\/]+)\)')
 
-    while (source := input('>> ')) != 'exit()':
+    while True:
+        try:
+            source = input('>> ')
+        except EOFError:
+            print()
+            break
 
-        if source == "clear()":
+        if source.strip() == 'exit()':
+            break
+        elif source.strip() == "clear()":
             clear()
         elif source == "update()":
             env = update(_path, env)


### PR DESCRIPTION
It is a common pattern to exit a repl inserting an EOF character (Ctrl+D in most unixes). This pull request makes that possible while also relaxing the strict comparison against the `exit()` and `clear()` strings. I noticed that if I introduced a space before the function name like this: `    exit()` then it wouldn't exit. An even better version of this would call a real exit function that would finish the thread.